### PR TITLE
move all unified recipes to own namespace

### DIFF
--- a/Common/src/main/java/com/almostreliable/unified/recipe/RecipeDumper.java
+++ b/Common/src/main/java/com/almostreliable/unified/recipe/RecipeDumper.java
@@ -67,7 +67,7 @@ public class RecipeDumper {
                     .sorted(Comparator.comparing(r -> r.getId().toString()))
                     .map(recipe -> "\t\t- " + recipe.getId() + "\n")
                     .collect(Collectors.joining("",
-                            "\t" + link.getMaster().getId() + " (Renamed to: " + link.createNewRecipeId() + ")\n",
+                            "\t" + link.getMaster().getId() + " (Renamed to: " + link.getMaster().createNewRecipeId() + ")\n",
                             "\n"))).collect(Collectors.joining("", type + " {\n", "}\n\n")));
         });
     }

--- a/Common/src/main/java/com/almostreliable/unified/recipe/RecipeLink.java
+++ b/Common/src/main/java/com/almostreliable/unified/recipe/RecipeLink.java
@@ -174,7 +174,7 @@ public class RecipeLink {
         StringBuilder sb = new StringBuilder();
         if (isUnified()) sb.append("u");
         if (hasDuplicateLink()) sb.append("d");
-        if (sb.length() > 0) sb.append("/");
+        if (!sb.isEmpty()) sb.append("/");
         sb.append(getId().getNamespace()).append("/").append(getId().getPath());
         return new ResourceLocation(BuildConfig.MOD_ID, sb.toString());
     }

--- a/Common/src/main/java/com/almostreliable/unified/recipe/RecipeLink.java
+++ b/Common/src/main/java/com/almostreliable/unified/recipe/RecipeLink.java
@@ -171,8 +171,20 @@ public class RecipeLink {
     }
 
     public ResourceLocation createNewRecipeId() {
-        String newId = String.format("%s_%s", getId().getNamespace(), getId().getPath());
-        return new ResourceLocation(BuildConfig.MOD_ID, newId);
+        StringBuilder sb = new StringBuilder();
+        if (isUnified()) sb.append("u");
+        if (hasDuplicateLink()) sb.append("d");
+        if (sb.length() > 0) sb.append("/");
+        sb.append(getId().getNamespace()).append("/").append(getId().getPath());
+        return new ResourceLocation(BuildConfig.MOD_ID, sb.toString());
+    }
+
+    public String getDumpInfo() {
+        if (isUnified() || hasDuplicateLink()) {
+            return getId() + " (Renamed to: " + createNewRecipeId() + ")";
+        }
+
+        return getId().toString();
     }
 
     public static final class DuplicateLink {

--- a/Common/src/main/java/com/almostreliable/unified/recipe/RecipeLink.java
+++ b/Common/src/main/java/com/almostreliable/unified/recipe/RecipeLink.java
@@ -170,6 +170,11 @@ public class RecipeLink {
         return getUnified() != null ? getUnified() : getOriginal();
     }
 
+    public ResourceLocation createNewRecipeId() {
+        String newId = String.format("%s_%s", getId().getNamespace(), getId().getPath());
+        return new ResourceLocation(BuildConfig.MOD_ID, newId);
+    }
+
     public static final class DuplicateLink {
         private final Set<RecipeLink> recipes = new HashSet<>();
         private RecipeLink currentMaster;
@@ -199,11 +204,6 @@ public class RecipeLink {
         @Override
         public String toString() {
             return "Link{currentMaster=" + currentMaster + ", recipes=" + recipes.size() + "}";
-        }
-
-        public ResourceLocation createNewRecipeId() {
-            String id = String.format("%s_%s", currentMaster.getId().getNamespace(), currentMaster.getId().getPath());
-            return new ResourceLocation(BuildConfig.MOD_ID, id);
         }
     }
 }

--- a/Common/src/main/java/com/almostreliable/unified/recipe/RecipeTransformer.java
+++ b/Common/src/main/java/com/almostreliable/unified/recipe/RecipeTransformer.java
@@ -118,8 +118,15 @@ public class RecipeTransformer {
         }
 
         for (RecipeLink.DuplicateLink link : duplicates) {
-            link.getRecipes().forEach(recipe -> onRemove.accept(recipe.getId()));
-            onAdd.accept(link.createNewRecipeId(), link.getMaster().getActual());
+            link.getRecipes().forEach(recipe -> {
+                onRemove.accept(recipe.getId());
+                unified.remove(recipe);
+            });
+            onAdd.accept(link.getMaster().createNewRecipeId(), link.getMaster().getActual());
+        }
+        for (RecipeLink link : unified) {
+            onRemove.accept(link.getId());
+            onAdd.accept(link.createNewRecipeId(), link.getActual());
         }
     }
 


### PR DESCRIPTION
Instead of moving only duplicate/merged recipes to our namespace, we should do that with all unified recipes.

This makes it clearly visible that a recipe was edited by the mod and prevents reports to other mod authors although their recipe was modified by us.