### PR TITLE
[1.19] Improve duplicate checks for implicit counts of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## Unreleased
+
+### Changed
+- improved duplicate checks for recipes with implicit counts of 1
+
 ## [0.3.0] - 2022-11-30
 
 ### Added

--- a/Common/src/main/java/com/almostreliable/unified/recipe/RecipeLink.java
+++ b/Common/src/main/java/com/almostreliable/unified/recipe/RecipeLink.java
@@ -46,8 +46,8 @@ public class RecipeLink {
 
         JsonObject compare = null;
         if (first.getType().toString().equals("minecraft:crafting_shaped")) {
-            compare = JsonCompare.compareShaped(selfActual, toCompareActual, compareSettings.getIgnoredFields());
-        } else if (JsonCompare.matches(selfActual, toCompareActual, compareSettings.getIgnoredFields())) {
+            compare = JsonCompare.compareShaped(selfActual, toCompareActual, compareSettings);
+        } else if (JsonCompare.matches(selfActual, toCompareActual, compareSettings)) {
             compare = JsonCompare.compare(compareSettings.getRules(), selfActual, toCompareActual);
         }
 

--- a/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
+++ b/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
@@ -106,9 +106,18 @@ public final class JsonCompare {
             JsonElement firstElem = first.get(firstKey);
             JsonElement secondElem = second.get(firstKey);
 
-            // sanitize elements for implicit 1 count
-            firstElem = sanitize(firstElem);
-            secondElem = sanitize(secondElem);
+            // the second element can still be null although the valid keys have the same size
+            if (secondElem == null) return false;
+
+            // sanitize elements for implicit counts of 1
+            if ((firstElem instanceof JsonArray firstArray && secondElem instanceof JsonArray secondArray &&
+                 firstArray.size() == secondArray.size()) ||
+                (firstElem instanceof JsonObject && secondElem instanceof JsonObject) ||
+                (firstElem instanceof JsonPrimitive && secondElem instanceof JsonObject) ||
+                (firstElem instanceof JsonObject && secondElem instanceof JsonPrimitive)) {
+                firstElem = sanitize(firstElem);
+                secondElem = sanitize(secondElem);
+            }
 
             if (!firstElem.equals(secondElem)) {
                 return false;

--- a/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
+++ b/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
@@ -110,11 +110,7 @@ public final class JsonCompare {
             if (secondElem == null) return false;
 
             // sanitize elements for implicit counts of 1
-            if ((firstElem instanceof JsonArray firstArray && secondElem instanceof JsonArray secondArray &&
-                 firstArray.size() == secondArray.size()) ||
-                (firstElem instanceof JsonObject && secondElem instanceof JsonObject) ||
-                (firstElem instanceof JsonPrimitive && secondElem instanceof JsonObject) ||
-                (firstElem instanceof JsonObject && secondElem instanceof JsonPrimitive)) {
+            if (needsSanitizing(firstElem, secondElem)) {
                 firstElem = sanitize(firstElem);
                 secondElem = sanitize(secondElem);
             }
@@ -125,6 +121,24 @@ public final class JsonCompare {
         }
 
         return true;
+    }
+
+    /**
+     * A check whether the given elements need to be sanitized. The purpose of this check is
+     * to save performance by skipping pairs that are not affected by sanitizing.
+     * <p>
+     * Conditions are both elements being a JSON array with the same size, both elements being
+     * a JSON object, one element being a JSON object and the other being a JSON primitive.
+     * @param firstElem the first element
+     * @param secondElem the second element
+     * @return true if the elements need to be sanitized, false otherwise
+     */
+    private static boolean needsSanitizing(JsonElement firstElem, JsonElement secondElem) {
+        return (firstElem instanceof JsonArray firstArray && secondElem instanceof JsonArray secondArray &&
+                firstArray.size() == secondArray.size()) ||
+               (firstElem instanceof JsonObject && secondElem instanceof JsonObject) ||
+               (firstElem instanceof JsonPrimitive && secondElem instanceof JsonObject) ||
+               (firstElem instanceof JsonObject && secondElem instanceof JsonPrimitive);
     }
 
     /**

--- a/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
+++ b/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
@@ -203,17 +203,24 @@ public final class JsonCompare {
                 return jsonObject;
             }
 
-            // add all other properties from the original object
-            for (var entry : jsonObject.entrySet()) {
-                if (!SANITIZE_KEYS.contains(entry.getKey()) && !entry.getKey().equals("count")) {
-                    sanitizedObject.add(entry.getKey(), entry.getValue());
-                }
-            }
-
+            mergeRemainingProperties(jsonObject, sanitizedObject);
             return sanitizedObject;
         }
 
         return createSanitizedObjectOrDefault(element, element);
+    }
+
+    /**
+     * Merges remaining properties from the original object to the sanitized object.
+     * @param jsonObject The original object
+     * @param sanitizedObject The sanitized object
+     */
+    private static void mergeRemainingProperties(JsonObject jsonObject, JsonObject sanitizedObject) {
+        for (var entry : jsonObject.entrySet()) {
+            if (!SANITIZE_KEYS.contains(entry.getKey()) && !entry.getKey().equals("count")) {
+                sanitizedObject.add(entry.getKey(), entry.getValue());
+            }
+        }
     }
 
     public interface Rule {

--- a/Common/src/main/java/com/almostreliable/unified/utils/JsonQuery.java
+++ b/Common/src/main/java/com/almostreliable/unified/utils/JsonQuery.java
@@ -3,6 +3,7 @@ package com.almostreliable.unified.utils;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
@@ -78,5 +79,26 @@ public class JsonQuery {
 
     public Optional<String> asString() {
         return asElement().filter(JsonElement::isJsonPrimitive).map(JsonElement::getAsString);
+    }
+
+    public Optional<Integer> asInt() {
+        return asElement().filter(JsonElement::isJsonPrimitive).map(JsonElement::getAsJsonPrimitive)
+                .filter(JsonPrimitive::isNumber).map(JsonElement::getAsInt);
+    }
+
+    public JsonQuery shallowCopy() {
+        if (element == null) {
+            return new JsonQuery();
+        }
+
+        if (element instanceof JsonObject jsonObject) {
+            var copyObject = new JsonObject();
+            for (var entry : jsonObject.entrySet()) {
+                copyObject.add(entry.getKey(), entry.getValue());
+            }
+            return new JsonQuery(copyObject);
+        }
+
+        throw new UnsupportedOperationException();
     }
 }

--- a/Common/src/test/java/com/almostreliable/unified/util/JsonCompareTest.java
+++ b/Common/src/test/java/com/almostreliable/unified/util/JsonCompareTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class JsonCompareTest {
-    public static String recipe = """
+    private static final String RECIPE = """
             {
               "type": "minecraft:smelting",
               "group": "coal",
@@ -27,8 +27,8 @@ public class JsonCompareTest {
 
     @Test
     public void simpleCompareFirst() {
-        JsonObject first = TestUtils.json(recipe, j -> j.addProperty("experience", 0.2));
-        JsonObject second = TestUtils.json(recipe); // 0.1 experience
+        JsonObject first = TestUtils.json(RECIPE, j -> j.addProperty("experience", 0.2));
+        JsonObject second = TestUtils.json(RECIPE); // 0.1 experience
 
         LinkedHashMap<String, JsonCompare.Rule> rules = new LinkedHashMap<>();
         rules.put("experience", new JsonCompare.LowerRule());
@@ -38,8 +38,8 @@ public class JsonCompareTest {
 
     @Test
     public void simpleCompareSecond() {
-        JsonObject first = TestUtils.json(recipe, j -> j.addProperty("experience", 0.05));
-        JsonObject second = TestUtils.json(recipe); // 0.1 experience
+        JsonObject first = TestUtils.json(RECIPE, j -> j.addProperty("experience", 0.05));
+        JsonObject second = TestUtils.json(RECIPE); // 0.1 experience
 
         LinkedHashMap<String, JsonCompare.Rule> rules = new LinkedHashMap<>();
         rules.put("experience", new JsonCompare.LowerRule());
@@ -49,8 +49,8 @@ public class JsonCompareTest {
 
     @Test
     public void compareHigherWins() {
-        JsonObject first = TestUtils.json(recipe, j -> j.addProperty("experience", 0.05));
-        JsonObject second = TestUtils.json(recipe); // 0.1 experience  // 0.1 experience
+        JsonObject first = TestUtils.json(RECIPE, j -> j.addProperty("experience", 0.05));
+        JsonObject second = TestUtils.json(RECIPE); // 0.1 experience  // 0.1 experience
 
         LinkedHashMap<String, JsonCompare.Rule> rules = new LinkedHashMap<>();
         rules.put("experience", new JsonCompare.HigherRule());
@@ -60,19 +60,19 @@ public class JsonCompareTest {
 
     @Test
     public void compareMulti() {
-        JsonObject a = TestUtils.json(recipe, j -> {
+        JsonObject a = TestUtils.json(RECIPE, j -> {
             j.addProperty("experience", 0.1);
             j.addProperty("cookingtime", 100);
         });
-        JsonObject b = TestUtils.json(recipe, j -> j.addProperty("experience", 0.1));
-        JsonObject c = TestUtils.json(recipe, j -> {
+        JsonObject b = TestUtils.json(RECIPE, j -> j.addProperty("experience", 0.1));
+        JsonObject c = TestUtils.json(RECIPE, j -> {
             j.addProperty("experience", 0.1);
             j.addProperty("cookingtime", 50);
         });
-        JsonObject d = TestUtils.json(recipe, j -> j.addProperty("experience", 0.2));
-        JsonObject e = TestUtils.json(recipe, j -> j.addProperty("experience", 0.2));
-        JsonObject f = TestUtils.json(recipe, j -> j.addProperty("experience", 0.1));
-        JsonObject g = TestUtils.json(recipe, j -> {
+        JsonObject d = TestUtils.json(RECIPE, j -> j.addProperty("experience", 0.2));
+        JsonObject e = TestUtils.json(RECIPE, j -> j.addProperty("experience", 0.2));
+        JsonObject f = TestUtils.json(RECIPE, j -> j.addProperty("experience", 0.1));
+        JsonObject g = TestUtils.json(RECIPE, j -> {
             j.addProperty("experience", 0.2);
             j.addProperty("cookingtime", 100);
         });
@@ -91,24 +91,24 @@ public class JsonCompareTest {
 
     @Test
     public void simpleMatch() {
-        JsonObject first = TestUtils.json(recipe);
-        JsonObject second = TestUtils.json(recipe);
+        JsonObject first = TestUtils.json(RECIPE);
+        JsonObject second = TestUtils.json(RECIPE);
         boolean matches = JsonCompare.matches(first, second, List.of());
         assertTrue(matches);
     }
 
     @Test
     public void noMatch() {
-        JsonObject first = TestUtils.json(recipe, j -> j.addProperty("experience", 100));
-        JsonObject second = TestUtils.json(recipe);
+        JsonObject first = TestUtils.json(RECIPE, j -> j.addProperty("experience", 100));
+        JsonObject second = TestUtils.json(RECIPE);
         boolean matches = JsonCompare.matches(first, second, List.of());
         assertFalse(matches);
     }
 
     @Test
     public void matchBecauseIgnore() {
-        JsonObject first = TestUtils.json(recipe, j -> j.addProperty("experience", 100));
-        JsonObject second = TestUtils.json(recipe);
+        JsonObject first = TestUtils.json(RECIPE, j -> j.addProperty("experience", 100));
+        JsonObject second = TestUtils.json(RECIPE);
         boolean matches = JsonCompare.matches(first, second, List.of("experience"));
         assertTrue(matches);
     }
@@ -202,5 +202,80 @@ public class JsonCompareTest {
         JsonObject second = TestUtils.json(recipe2);
         JsonObject result = JsonCompare.compareShaped(first, second, List.of("pattern", "key"));
         assertEquals(first, result);
+    }
+
+    @Test
+    public void sanitizeImplicitCount() {
+        String recipe1 = """
+                {
+                  "type": "minecraft:crafting_shaped",
+                  "pattern": [
+                    "iii",
+                    "iii",
+                    "iii"
+                  ],
+                  "key": {
+                    "i": {
+                      "tag": "forge:raw_materials/iron"
+                    }
+                  },
+                  "result": "minecraft:iron_ingot"
+                }
+                """;
+        String recipe2 = """
+                {
+                  "type": "minecraft:crafting_shaped",
+                  "pattern": [
+                    "iii",
+                    "iii",
+                    "iii"
+                  ],
+                  "key": {
+                    "i": {
+                      "tag": "forge:raw_materials/iron"
+                    }
+                  },
+                  "result": {
+                    "item": "minecraft:iron_ingot",
+                    "count": 1
+                  }
+                }
+                """;
+
+        JsonObject first = TestUtils.json(recipe1);
+        JsonObject second = TestUtils.json(recipe2);
+        JsonObject result = JsonCompare.compareShaped(first, second, List.of("pattern", "key"));
+        assertEquals(first, result);
+    }
+
+    @Test
+    public void sanitizeImplicitCountNested() {
+        String recipe1 = """
+                {
+                  "type": "create:crushing",
+                  "ingredients": [{ "tag": "forge:raw_materials/lead" }],
+                  "processingTime": 400,
+                  "results": [
+                    { "item": "emendatusenigmatica:crushed_lead_ore" },
+                    { "chance": 0.75, "item": "create:experience_nugget" }
+                  ]
+                }
+                """;
+        String recipe2 = """
+                {
+                  "type": "create:crushing",
+                  "ingredients": [{ "tag": "forge:raw_materials/lead" }],
+                  "processingTime": 400,
+                  "results": [
+                    { "count": 1, "item": "emendatusenigmatica:crushed_lead_ore" },
+                    { "chance": 0.75, "count": 1, "item": "create:experience_nugget" }
+                  ]
+                }
+                """;
+
+        JsonObject first = TestUtils.json(recipe1);
+        JsonObject second = TestUtils.json(recipe2);
+        boolean result = JsonCompare.matches(first, second, List.of());
+        assertTrue(result);
     }
 }


### PR DESCRIPTION
The sanitizing was initially applied to all possible elements but this obviously drastically increased load times.
I did some benchmarking on the dev version of Enigmatica 9 with EE. Here are the results.

Old version (no implicit count checks):
8.853ms

New version (sanitized every element):
18.330ms

With basic type filter:
17.273ms
```java
if (firstElem.getClass() == secondElem.getClass() ||
    (firstElem instanceof JsonPrimitive && secondElem instanceof JsonObject) ||
    (firstElem instanceof JsonObject && secondElem instanceof JsonPrimitive)) {
    firstElem = sanitize(firstElem);
    secondElem = sanitize(secondElem);
}
```

With basic type filter and array length checks:
17.068ms
```java
if ((firstElem instanceof JsonArray firstArray && secondElem instanceof JsonArray secondArray &&
     firstArray.size() == secondArray.size()) ||
    firstElem.getClass() == secondElem.getClass() ||
    (firstElem instanceof JsonPrimitive && secondElem instanceof JsonObject) ||
    (firstElem instanceof JsonObject && secondElem instanceof JsonPrimitive)) {
    firstElem = sanitize(firstElem);
    secondElem = sanitize(secondElem);
}
```

With type filter, array length checks and without primitives:
14.593ms
```java
if ((firstElem instanceof JsonArray firstArray && secondElem instanceof JsonArray secondArray &&
     firstArray.size() == secondArray.size()) ||
    (firstElem instanceof JsonObject && secondElem instanceof JsonObject) ||
    (firstElem instanceof JsonPrimitive && secondElem instanceof JsonObject) ||
    (firstElem instanceof JsonObject && secondElem instanceof JsonPrimitive)) {
    firstElem = sanitize(firstElem);
    secondElem = sanitize(secondElem);
}
```

The last method has an insanely ugly condition but it's only 5.740ms slower than the version without any sanitizing and implicit count checks at all.