### PR TITLE
Several performance improvements

### DIFF
--- a/Common/src/main/java/com/almostreliable/unified/config/DuplicationConfig.java
+++ b/Common/src/main/java/com/almostreliable/unified/config/DuplicationConfig.java
@@ -37,10 +37,19 @@ public class DuplicationConfig extends Config {
          * Avoid needlessly computing a regex match on every recipe by caching whether the type should be ignored or not.
          */
         boolean isTypeIgnored = recipeTypeIgnoredCache.computeIfAbsent(recipe.getType(), type -> {
-            return ignoreRecipeTypes.stream().anyMatch(pattern -> pattern.matcher(type.toString()).matches());
+            for(Pattern ignorePattern : ignoreRecipeTypes) {
+                if(ignorePattern.matcher(type.toString()).matches())
+                    return true;
+            }
+            return false;
         });
-        return isTypeIgnored ||
-               ignoreRecipes.stream().anyMatch(pattern -> pattern.matcher(recipe.getId().toString()).matches());
+        if(isTypeIgnored)
+            return true;
+        for(Pattern ignoreRecipePattern : ignoreRecipes) {
+            if(ignoreRecipePattern.matcher(recipe.getId().toString()).matches())
+                return true;
+        }
+        return false;
     }
 
     public JsonCompare.CompareSettings getCompareSettings(ResourceLocation type) {

--- a/Common/src/main/java/com/almostreliable/unified/config/DuplicationConfig.java
+++ b/Common/src/main/java/com/almostreliable/unified/config/DuplicationConfig.java
@@ -33,23 +33,34 @@ public class DuplicationConfig extends Config {
     }
 
     public boolean shouldIgnoreRecipe(RecipeLink recipe) {
-        /*
-         * Avoid needlessly computing a regex match on every recipe by caching whether the type should be ignored or not.
-         */
-        boolean isTypeIgnored = recipeTypeIgnoredCache.computeIfAbsent(recipe.getType(), type -> {
-            for(Pattern ignorePattern : ignoreRecipeTypes) {
-                if(ignorePattern.matcher(type.toString()).matches())
+        if (isRecipeTypeIgnored(recipe)) {
+            return true;
+        }
+
+        for (Pattern ignoreRecipePattern : ignoreRecipes) {
+            if (ignoreRecipePattern.matcher(recipe.getId().toString()).matches()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the recipe type is ignored. This is cached to avoid having to recompute the regex for every recipe.
+     *
+     * @param recipe The recipe to check
+     * @return True if the recipe type is ignored, false otherwise
+     */
+    private boolean isRecipeTypeIgnored(RecipeLink recipe) {
+        return recipeTypeIgnoredCache.computeIfAbsent(recipe.getType(), type -> {
+            for (Pattern ignorePattern : ignoreRecipeTypes) {
+                if (ignorePattern.matcher(type.toString()).matches()) {
                     return true;
+                }
             }
             return false;
         });
-        if(isTypeIgnored)
-            return true;
-        for(Pattern ignoreRecipePattern : ignoreRecipes) {
-            if(ignoreRecipePattern.matcher(recipe.getId().toString()).matches())
-                return true;
-        }
-        return false;
     }
 
     public JsonCompare.CompareSettings getCompareSettings(ResourceLocation type) {

--- a/Common/src/main/java/com/almostreliable/unified/config/DuplicationConfig.java
+++ b/Common/src/main/java/com/almostreliable/unified/config/DuplicationConfig.java
@@ -21,7 +21,7 @@ public class DuplicationConfig extends Config {
     private final Set<Pattern> ignoreRecipeTypes;
     private final Set<Pattern> ignoreRecipes;
     private final boolean strictMode;
-    private final HashMap<ResourceLocation, Boolean> recipeTypeIgnoredCache;
+    private final HashMap<ResourceLocation, Boolean> ignoredRecipeTypesCache;
 
     public DuplicationConfig(JsonCompare.CompareSettings defaultRules, LinkedHashMap<ResourceLocation, JsonCompare.CompareSettings> overrideRules, Set<Pattern> ignoreRecipeTypes, Set<Pattern> ignoreRecipes, boolean strictMode) {
         this.defaultRules = defaultRules;
@@ -29,7 +29,7 @@ public class DuplicationConfig extends Config {
         this.ignoreRecipeTypes = ignoreRecipeTypes;
         this.ignoreRecipes = ignoreRecipes;
         this.strictMode = strictMode;
-        this.recipeTypeIgnoredCache = new HashMap<>();
+        this.ignoredRecipeTypesCache = new HashMap<>();
     }
 
     public boolean shouldIgnoreRecipe(RecipeLink recipe) {
@@ -53,7 +53,7 @@ public class DuplicationConfig extends Config {
      * @return True if the recipe type is ignored, false otherwise
      */
     private boolean isRecipeTypeIgnored(RecipeLink recipe) {
-        return recipeTypeIgnoredCache.computeIfAbsent(recipe.getType(), type -> {
+        return ignoredRecipeTypesCache.computeIfAbsent(recipe.getType(), type -> {
             for (Pattern ignorePattern : ignoreRecipeTypes) {
                 if (ignorePattern.matcher(type.toString()).matches()) {
                     return true;
@@ -69,6 +69,10 @@ public class DuplicationConfig extends Config {
 
     public boolean isStrictMode() {
         return strictMode;
+    }
+
+    public void clearCache() {
+        ignoredRecipeTypesCache.clear();
     }
 
     public static class Serializer extends Config.Serializer<DuplicationConfig> {

--- a/Common/src/main/java/com/almostreliable/unified/recipe/RecipeTransformer.java
+++ b/Common/src/main/java/com/almostreliable/unified/recipe/RecipeTransformer.java
@@ -75,6 +75,7 @@ public class RecipeTransformer {
         });
 
         AlmostUnified.LOG.warn("Recipe count afterwards: " + recipes.size() + " (done in " + transformationTimer.stop() + ")");
+        duplicationConfig.clearCache();
         if (tracker != null) recipes.putAll(tracker.compute());
         return result;
     }

--- a/Common/src/main/java/com/almostreliable/unified/recipe/RecipeTransformer.java
+++ b/Common/src/main/java/com/almostreliable/unified/recipe/RecipeTransformer.java
@@ -8,6 +8,7 @@ import com.almostreliable.unified.utils.JsonCompare;
 import com.almostreliable.unified.utils.JsonQuery;
 import com.almostreliable.unified.utils.RecipeTypePropertiesLogger;
 import com.almostreliable.unified.utils.ReplacementMap;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.gson.JsonArray;
@@ -54,6 +55,7 @@ public class RecipeTransformer {
      * @return The result of the transformation.
      */
     public Result transformRecipes(Map<ResourceLocation, JsonElement> recipes, boolean skipClientTracking) {
+        Stopwatch transformationTimer = Stopwatch.createStarted();
         AlmostUnified.LOG.warn("Recipe count: " + recipes.size());
 
         ClientRecipeTracker.RawBuilder tracker = skipClientTracking ? null : new ClientRecipeTracker.RawBuilder();
@@ -72,7 +74,7 @@ public class RecipeTransformer {
             result.addAll(recipeLinks);
         });
 
-        AlmostUnified.LOG.warn("Recipe count afterwards: " + recipes.size());
+        AlmostUnified.LOG.warn("Recipe count afterwards: " + recipes.size() + " (done in " + transformationTimer.stop() + ")");
         if (tracker != null) recipes.putAll(tracker.compute());
         return result;
     }

--- a/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
+++ b/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
@@ -90,21 +90,16 @@ public final class JsonCompare {
 
     public static boolean matches(JsonObject first, JsonObject second, CompareSettings compareSettings) {
         Collection<String> ignoredFields = compareSettings.getIgnoredFields();
-        if(ignoredFields.isEmpty()) {
-            // optimization: check if the objects have the same number of keys, since we won't be filtering any
-            if(first.size() != second.size())
-                return false;
+        if (ignoredFields.isEmpty() && first.size() != second.size()) {
+            return false;
         }
 
-        // iterate using entrySet to avoid needing to call get() on JsonObject (it is an O(log(n)) operation)
-        for(Map.Entry<String, JsonElement> firstEntry : first.entrySet()) {
-            if(ignoredFields.contains(firstEntry.getKey()))
-                continue;
+        for (Map.Entry<String, JsonElement> firstEntry : first.entrySet()) {
+            if (ignoredFields.contains(firstEntry.getKey())) continue;
 
             JsonElement firstElem = firstEntry.getValue();
             JsonElement secondElem = second.get(firstEntry.getKey());
 
-            // if the key doesn't exist on the second element, they are clearly not equal
             if (secondElem == null) return false;
 
             // sanitize elements for implicit counts of 1

--- a/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
+++ b/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
@@ -90,24 +90,21 @@ public final class JsonCompare {
 
     public static boolean matches(JsonObject first, JsonObject second, CompareSettings compareSettings) {
         Collection<String> ignoredFields = compareSettings.getIgnoredFields();
-        List<String> firstValidKeys = first
-                .keySet()
-                .stream()
-                .filter(key -> !ignoredFields.contains(key))
-                .toList();
-        List<String> secondValidKeys = second
-                .keySet()
-                .stream()
-                .filter(key -> !ignoredFields.contains(key))
-                .toList();
+        if(ignoredFields.isEmpty()) {
+            // optimization: check if the objects have the same number of keys, since we won't be filtering any
+            if(first.size() != second.size())
+                return false;
+        }
 
-        if (firstValidKeys.size() != secondValidKeys.size()) return false;
+        // iterate using entrySet to avoid needing to call get() on JsonObject (it is an O(log(n)) operation)
+        for(Map.Entry<String, JsonElement> firstEntry : first.entrySet()) {
+            if(ignoredFields.contains(firstEntry.getKey()))
+                continue;
 
-        for (String firstKey : firstValidKeys) {
-            JsonElement firstElem = first.get(firstKey);
-            JsonElement secondElem = second.get(firstKey);
+            JsonElement firstElem = firstEntry.getValue();
+            JsonElement secondElem = second.get(firstEntry.getKey());
 
-            // the second element can still be null although the valid keys have the same size
+            // if the key doesn't exist on the second element, they are clearly not equal
             if (secondElem == null) return false;
 
             // sanitize elements for implicit counts of 1


### PR DESCRIPTION
## Proposed Changes

This PR implements a number of optimizations designed to reduce the time spent running recipe transformations. This was done by carefully profiling a world load during Enigmatica 8 and then targeting the obvious bottlenecks. I have summarized the changes I made below.

- `DuplicationConfig.shouldIgnoreRecipe` has been optimized to avoid matching regexes as much as possible. In particular, whether or not a given recipe type ID is ignored is now cached. This saves a regex match for almost all recipes, as many of them will share the same type.
- In the same method, use of streams was replaced with standard for loops. This is to help reduce allocations and needless overhead since this code is run on every single recipe.

As a result of the above optimizations, this method is now about 4 times faster (which can be seen in the profiler results). I believe 2 seconds is enough of a difference that it's not just caused by Java's random speed variation between runs.

Most of the remaining time is spent within `handleDuplicate`, which essentially boils down to calling `JsonCompare.matches`. Unfortunately, checking two JSON objects for equality is a rather inefficient process in general, as [key retrieval is O(log(n)) in tree maps](https://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html). Nonetheless I was able to make a couple changes that reduced running time by about 40%.

- I removed the original logic that first looped over the key sets and checked whether the fields were ignored. This logic added quite a bit of overhead as can be seen in this profiler excerpt:
![image](https://user-images.githubusercontent.com/42941056/223899168-a59fa9dc-3507-4ded-8d85-b8ec81a6f2f4.png)
Instead the logic was replaced with a simpler for loop that loops over each entry of one of the JSON objects, skips any keys that should be ignored, and attempts to retrieve the same key from the other object. In particular, this eliminates the need to call `get` on one of the objects entirely, as we can simply iterate over its entries and be given both a key and value at the same time.

Unfortunately this method is still bottlenecked by the `JsonObject.get` call. Further improvements are probably not possible without a cleverer solution that reduces the number of recipes being compared.

Lastly, I added a timer to `RecipeTransformer.transformRecipes` in order to see how long the process takes even when the profiler is not running.

I would appreciate if you could give these changes a try to verify that they don't only increase performance on ancient hardware. Let me know if you have any questions/feedback.

## Additional Context

Profiler screenshot from latest 1.18 version:

![before_au](https://user-images.githubusercontent.com/42941056/223897962-5597b53a-9420-4612-91df-46a0684da0e4.png)

Profiler screenshot after this PR:

![after_au](https://user-images.githubusercontent.com/42941056/223897984-0dbdb6f0-f441-4101-8538-3a6f41383503.png)

I believe the time increase in `unifyRecipes` was simply an artifact of garbage collection/some other stall (I have very few CPU cores), and in any case the total runtime is clearly shorter.