### PR TITLE
Add Ars Nouveau compat

### DIFF
--- a/Common/src/main/java/com/almostreliable/unified/api/ModConstants.java
+++ b/Common/src/main/java/com/almostreliable/unified/api/ModConstants.java
@@ -9,10 +9,10 @@ public final class ModConstants {
     // custom unify handlers
     public static final String AD_ASTRA = "ad_astra";
     public static final String AMETHYST_IMBUEMENT = "amethyst_imbuement";
+    public static final String ARS_NOUVEAU = "ars_nouveau";
     public static final String IMMERSIVE_ENGINEERING = "immersiveengineering";
     public static final String MEKANISM = "mekanism";
     public static final String MODERN_INDUSTRIALIZATION = "modern_industrialization";
-    public static final String ARS_NOUVEAU = "ars_nouveau";
 
     private ModConstants() {}
 }

--- a/Common/src/main/java/com/almostreliable/unified/api/ModConstants.java
+++ b/Common/src/main/java/com/almostreliable/unified/api/ModConstants.java
@@ -12,6 +12,7 @@ public final class ModConstants {
     public static final String IMMERSIVE_ENGINEERING = "immersiveengineering";
     public static final String MEKANISM = "mekanism";
     public static final String MODERN_INDUSTRIALIZATION = "modern_industrialization";
+    public static final String ARS_NOUVEAU = "ars_nouveau";
 
     private ModConstants() {}
 }

--- a/Common/src/main/java/com/almostreliable/unified/api/recipe/RecipeConstants.java
+++ b/Common/src/main/java/com/almostreliable/unified/api/recipe/RecipeConstants.java
@@ -38,5 +38,8 @@ public final class RecipeConstants {
     public static final String ITEM_INPUTS = "item_inputs";
     public static final String ITEM_OUTPUTS = "item_outputs";
 
+    // ars nouveau
+    public static final String PEDESTAL_ITEMS = "pedestalItems";
+
     private RecipeConstants() {}
 }

--- a/Common/src/main/java/com/almostreliable/unified/api/recipe/RecipeConstants.java
+++ b/Common/src/main/java/com/almostreliable/unified/api/recipe/RecipeConstants.java
@@ -20,6 +20,10 @@ public final class RecipeConstants {
     // inner keys
     public static final String VALUE = "value";
 
+    // ars nouveau
+    public static final String PEDESTAL_ITEMS = "pedestalItems";
+    public static final String REAGENT = "reagent";
+
     // immersive engineering
     public static final String INPUT_0 = "input0";
     public static final String INPUT_1 = "input1";
@@ -37,10 +41,6 @@ public final class RecipeConstants {
     // modern industrialization
     public static final String ITEM_INPUTS = "item_inputs";
     public static final String ITEM_OUTPUTS = "item_outputs";
-
-    // ars nouveau
-    public static final String PEDESTAL_ITEMS = "pedestalItems";
-    public static final String REAGENT = "reagent";
 
     private RecipeConstants() {}
 }

--- a/Common/src/main/java/com/almostreliable/unified/api/recipe/RecipeConstants.java
+++ b/Common/src/main/java/com/almostreliable/unified/api/recipe/RecipeConstants.java
@@ -40,6 +40,7 @@ public final class RecipeConstants {
 
     // ars nouveau
     public static final String PEDESTAL_ITEMS = "pedestalItems";
+    public static final String REAGENT = "reagent";
 
     private RecipeConstants() {}
 }

--- a/Forge/src/main/java/com/almostreliable/unified/AlmostUnifiedPlatformForge.java
+++ b/Forge/src/main/java/com/almostreliable/unified/AlmostUnifiedPlatformForge.java
@@ -61,9 +61,9 @@ public class AlmostUnifiedPlatformForge implements AlmostUnifiedPlatform {
     @Override
     public void bindRecipeHandlers(RecipeHandlerFactory factory) {
         factory.registerForMod(ModConstants.AD_ASTRA, new AdAstraRecipeUnifier());
+        factory.registerForMod(ModConstants.ARS_NOUVEAU, new ArsNouveauRecipeUnifier());
         factory.registerForMod(ModConstants.IMMERSIVE_ENGINEERING, new ImmersiveEngineeringRecipeUnifier());
         factory.registerForMod(ModConstants.MEKANISM, new MekanismRecipeUnifier());
-        factory.registerForMod(ModConstants.ARS_NOUVEAU, new ArsNouveauRecipeUnifier());
     }
 
     @Override

--- a/Forge/src/main/java/com/almostreliable/unified/AlmostUnifiedPlatformForge.java
+++ b/Forge/src/main/java/com/almostreliable/unified/AlmostUnifiedPlatformForge.java
@@ -2,6 +2,7 @@ package com.almostreliable.unified;
 
 import com.almostreliable.unified.api.ModConstants;
 import com.almostreliable.unified.compat.AdAstraRecipeUnifier;
+import com.almostreliable.unified.compat.ArsNouveauRecipeUnifier;
 import com.almostreliable.unified.compat.ImmersiveEngineeringRecipeUnifier;
 import com.almostreliable.unified.compat.MekanismRecipeUnifier;
 import com.almostreliable.unified.recipe.unifier.RecipeHandlerFactory;
@@ -62,6 +63,7 @@ public class AlmostUnifiedPlatformForge implements AlmostUnifiedPlatform {
         factory.registerForMod(ModConstants.AD_ASTRA, new AdAstraRecipeUnifier());
         factory.registerForMod(ModConstants.IMMERSIVE_ENGINEERING, new ImmersiveEngineeringRecipeUnifier());
         factory.registerForMod(ModConstants.MEKANISM, new MekanismRecipeUnifier());
+        factory.registerForMod(ModConstants.ARS_NOUVEAU, new ArsNouveauRecipeUnifier());
     }
 
     @Override

--- a/Forge/src/main/java/com/almostreliable/unified/compat/ArsNouveauRecipeUnifier.java
+++ b/Forge/src/main/java/com/almostreliable/unified/compat/ArsNouveauRecipeUnifier.java
@@ -1,0 +1,29 @@
+package com.almostreliable.unified.compat;
+
+import com.almostreliable.unified.api.recipe.RecipeConstants;
+import com.almostreliable.unified.api.recipe.RecipeUnifier;
+import com.almostreliable.unified.api.recipe.RecipeUnifierBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+public class ArsNouveauRecipeUnifier implements RecipeUnifier {
+    @Override
+    public void collectUnifier(RecipeUnifierBuilder builder) {
+        // pedestalItems is a JsonArray with a JsonObject of {"item":Ingredient}
+        builder.put(RecipeConstants.PEDESTAL_ITEMS, JsonArray.class, (json, ctx) -> {
+            for (int i = 0; i < json.size(); i++) {
+                JsonElement entry = json.get(i);
+                JsonElement result = null;
+                if (entry instanceof JsonObject jsonEntry) {
+                    result = ctx.createIngredientReplacement(jsonEntry.get(RecipeConstants.ITEM));
+                }
+                if (result != null) {
+                    JsonObject resultObj = new JsonObject();
+                    resultObj.add(RecipeConstants.ITEM, result);
+                    json.set(i, resultObj);
+                }
+            }
+            return json;
+        });
+    }
+}

--- a/Forge/src/main/java/com/almostreliable/unified/compat/ArsNouveauRecipeUnifier.java
+++ b/Forge/src/main/java/com/almostreliable/unified/compat/ArsNouveauRecipeUnifier.java
@@ -25,5 +25,6 @@ public class ArsNouveauRecipeUnifier implements RecipeUnifier {
             }
             return json;
         });
+        builder.put(RecipeConstants.REAGENT, (json, ctx) -> ctx.createIngredientReplacement(json));
     }
 }

--- a/Forge/src/main/java/com/almostreliable/unified/compat/ArsNouveauRecipeUnifier.java
+++ b/Forge/src/main/java/com/almostreliable/unified/compat/ArsNouveauRecipeUnifier.java
@@ -1,30 +1,40 @@
 package com.almostreliable.unified.compat;
 
 import com.almostreliable.unified.api.recipe.RecipeConstants;
+import com.almostreliable.unified.api.recipe.RecipeContext;
 import com.almostreliable.unified.api.recipe.RecipeUnifier;
 import com.almostreliable.unified.api.recipe.RecipeUnifierBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
+import javax.annotation.Nullable;
+
 public class ArsNouveauRecipeUnifier implements RecipeUnifier {
+
     @Override
     public void collectUnifier(RecipeUnifierBuilder builder) {
-        // pedestalItems is a JsonArray with a JsonObject of {"item":Ingredient}
-        builder.put(RecipeConstants.PEDESTAL_ITEMS, JsonArray.class, (json, ctx) -> {
-            for (int i = 0; i < json.size(); i++) {
-                JsonElement entry = json.get(i);
-                JsonElement result = null;
-                if (entry instanceof JsonObject jsonEntry) {
-                    result = ctx.createIngredientReplacement(jsonEntry.get(RecipeConstants.ITEM));
-                }
-                if (result != null) {
-                    JsonObject resultObj = new JsonObject();
-                    resultObj.add(RecipeConstants.ITEM, result);
-                    json.set(i, resultObj);
-                }
-            }
-            return json;
-        });
+        // imbuement, enchanting apparatus, enchantment, reactive enchantment, spell write, armor upgrade
+        builder.forEachObject(RecipeConstants.PEDESTAL_ITEMS, this::createIngredientReplacement);
+        // glyph
+        builder.forEachObject(RecipeConstants.INPUT_ITEMS, this::createIngredientReplacement);
+
+        // enchanting apparatus
         builder.put(RecipeConstants.REAGENT, (json, ctx) -> ctx.createIngredientReplacement(json));
+    }
+
+    /**
+     * Handles ingredient replacements for JSON arrays with nested item JSON objects.
+     *
+     * @param json The JSON object to apply the replacement on.
+     * @param ctx  The recipe context.
+     * @return The JSON object with the replacement applied, or {@code null} if there is no replacement.
+     */
+    @Nullable
+    private JsonObject createIngredientReplacement(JsonObject json, RecipeContext ctx) {
+        var replacement = ctx.createIngredientReplacement(json.get(RecipeConstants.ITEM));
+        if (replacement instanceof JsonObject item) {
+            json.add(RecipeConstants.ITEM, item);
+            return json;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Proposed Changes
- support for the `pedestalItems` recipe key in Ars Nouveau Enchanting Apparatus and Imbuement recipes
- support for the `inputItems` recipe key in Ars Nouveau Glyph recipes
- support for the `reagent` recipe key in Ars Nouveau Enchanting Apparatus