### PR TITLE
Update Defaults.java

### DIFF
--- a/Common/src/main/java/com/almostreliable/unified/config/Defaults.java
+++ b/Common/src/main/java/com/almostreliable/unified/config/Defaults.java
@@ -132,7 +132,7 @@ public final class Defaults {
     public static List<String> getIgnoredRecipeTypes(Platform platform) {
         return switch (platform) {
             case FORGE -> List.of("cucumber:shaped_tag");
-            case FABRIC -> List.of();
+            case FABRIC -> List.of("cucumber:shaped_tag");
         };
     }
 

--- a/Common/src/main/java/com/almostreliable/unified/config/Defaults.java
+++ b/Common/src/main/java/com/almostreliable/unified/config/Defaults.java
@@ -131,8 +131,7 @@ public final class Defaults {
 
     public static List<String> getIgnoredRecipeTypes(Platform platform) {
         return switch (platform) {
-            case FORGE -> List.of("cucumber:shaped_tag");
-            case FABRIC -> List.of("cucumber:shaped_tag");
+            default -> List.of("cucumber:shaped_tag");
         };
     }
 


### PR DESCRIPTION
Compatibility with ported Cucumber Library version for Fabric

## Proposed Changes
Add `"cucumber:shaped_tag"` to default` "IgnoredRecipeTypes" ` on Fabric
I'm porting Cucumber Library for Fabric and this would be essential to be added for the correct functioning of the mod