### PR TITLE
Register the MI unifier for EI

### DIFF
--- a/Common/src/main/java/com/almostreliable/unified/api/constant/ModConstants.java
+++ b/Common/src/main/java/com/almostreliable/unified/api/constant/ModConstants.java
@@ -25,6 +25,7 @@ public interface ModConstants {
     String INTEGRATED_DYNAMICS = "integrateddynamics";
     String MEKANISM = "mekanism";
     String MODERN_INDUSTRIALIZATION = "modern_industrialization";
+    String EXTENDED_INDUSTRIALIZATION = "extended_industrialization";
     String OCCULTISM = "occultism";
     String PRODUCTIVE_TREES = "productivetrees";
     String THEURGY = "theurgy";

--- a/NeoForge/src/main/java/com/almostreliable/unified/core/NeoForgePlugin.java
+++ b/NeoForge/src/main/java/com/almostreliable/unified/core/NeoForgePlugin.java
@@ -43,6 +43,7 @@ public class NeoForgePlugin implements AlmostUnifiedPlugin {
         registry.registerForModId(ModConstants.INTEGRATED_DYNAMICS, new IntegratedDynamicsRecipeUnifier());
         registry.registerForModId(ModConstants.MEKANISM, new MekanismRecipeUnifier());
         registry.registerForModId(ModConstants.MODERN_INDUSTRIALIZATION, new ModernIndustrializationRecipeUnifier());
+        registry.registerForModId(ModConstants.EXTENDED_INDUSTRIALIZATION, new ModernIndustrializationRecipeUnifier());
         registry.registerForModId(ModConstants.OCCULTISM, new OccultismRecipeUnifier());
         registry.registerForModId(ModConstants.PRODUCTIVE_TREES, new ProductiveTreesRecipeUnifier());
         registry.registerForModId(ModConstants.THEURGY, new TheurgyRecipeUnifier());


### PR DESCRIPTION
## Issue Reference
https://github.com/AllTheMods/ATM-10/issues/475

## Proposed Changes
EI uses the same `item_inputs` and `item_outputs` format for it's recipes as MI. Registering the unifier for EI aims to fix inconsistency between Mixer and Alloy Smelter recipes, as well as allow unifying EI recipes in general.

https://github.com/Swedz/Extended-Industrialization/blob/1.21.1/src/generated/resources/data/extended_industrialization/recipe/materials/cupronickel/alloy_smelter/ingot.json
