### PR TITLE
Optimize startup time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - fixed `c:ores_in_ground` block tag not being considered when no respective item tag is present
 - fixed stone variant defaults not using the correct registry names
+- improved performance for unification ([mezz](https://github.com/mezz)@[#97](https://github.com/AlmostReliable/almostunified/pull/97))
 
 ## [1.2.2] - 2024-10-23
 

--- a/Common/src/main/java/com/almostreliable/unified/config/DuplicateConfig.java
+++ b/Common/src/main/java/com/almostreliable/unified/config/DuplicateConfig.java
@@ -62,10 +62,12 @@ public final class DuplicateConfig extends Config {
     private boolean isRecipeTypeIgnored(RecipeLink recipe) {
         ResourceLocation type = recipe.getType();
         Boolean ignored = ignoredRecipeTypesCache.get(type);
+
         if (ignored == null) {
             ignored = computeIsRecipeTypeIgnored(type.toString());
             ignoredRecipeTypesCache.put(type, ignored);
         }
+
         return ignored;
     }
 
@@ -75,6 +77,7 @@ public final class DuplicateConfig extends Config {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/Common/src/main/java/com/almostreliable/unified/config/DuplicateConfig.java
+++ b/Common/src/main/java/com/almostreliable/unified/config/DuplicateConfig.java
@@ -63,17 +63,15 @@ public final class DuplicateConfig extends Config {
         ResourceLocation type = recipe.getType();
         Boolean ignored = ignoredRecipeTypesCache.get(type);
         if (ignored == null) {
-            ignored = computeIsRecipeTypeIgnored(recipe);
+            ignored = computeIsRecipeTypeIgnored(type.toString());
             ignoredRecipeTypesCache.put(type, ignored);
         }
         return ignored;
     }
 
-    private boolean computeIsRecipeTypeIgnored(RecipeLink recipe) {
-        ResourceLocation type = recipe.getType();
-        String typeString = type.toString();
+    private boolean computeIsRecipeTypeIgnored(String recipeType) {
         for (Pattern ignorePattern : ignoreRecipeTypes) {
-            if (ignorePattern.matcher(typeString).matches()) {
+            if (ignorePattern.matcher(recipeType).matches()) {
                 return true;
             }
         }

--- a/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
+++ b/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
@@ -64,9 +64,9 @@ public final class RecipeLink implements RecipeData {
      * If base comparison succeed then the recipes will be compared for equality with rules from {@link JsonCompare.Rule}.
      * Rules are sorted, first rule with the highest priority will be used.
      *
-     * @param first           first recipe to compare
-     * @param second          second recipe to compare
-     * @param compareContext  Settings and context to use for comparison.
+     * @param first          first recipe to compare
+     * @param second         second recipe to compare
+     * @param compareContext Settings and context to use for comparison.
      * @return the recipe where rules are applied and the recipes are compared for equality, or null if the recipes are not equal
      */
     @Nullable
@@ -154,8 +154,8 @@ public final class RecipeLink implements RecipeData {
      * Checks for duplicate against given recipe data. If recipe data already has a duplicate link,
      * the master from the link will be used. Otherwise, we will create a new link if needed.
      *
-     * @param otherRecipe     Recipe data to check for duplicate against.
-     * @param compareContext  Settings and context to use for comparison.
+     * @param otherRecipe    Recipe data to check for duplicate against.
+     * @param compareContext Settings and context to use for comparison.
      * @return True if recipe is a duplicate, false otherwise.
      */
     public boolean handleDuplicate(RecipeLink otherRecipe, JsonCompare.CompareContext compareContext) {

--- a/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
+++ b/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
@@ -40,7 +40,8 @@ public final class RecipeLink implements RecipeData {
     @Nullable
     public static RecipeLink of(ResourceLocation id, JsonObject originalRecipe) {
         try {
-            ResourceLocation type = ResourceLocation.parse(originalRecipe.get("type").getAsString());
+            String typeString = originalRecipe.get("type").getAsString();
+            ResourceLocation type = PARSED_TYPE_CACHE.computeIfAbsent(typeString, ResourceLocation::parse);
             return new RecipeLink(id, originalRecipe, type);
         } catch (Exception e) {
             AlmostUnifiedCommon.LOGGER.warn("Could not detect recipe type for recipe '{}', skipping.", id);

--- a/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeTransformer.java
+++ b/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeTransformer.java
@@ -138,7 +138,8 @@ public class RecipeTransformer {
             return false;
         }
 
-        JsonCompare.CompareSettings compareSettings = duplicateConfig.getCompareSettings(curRecipe.getType());
+        JsonCompare.CompareContext compareContext = duplicateConfig.getCompareContext(curRecipe);
+
         boolean foundDuplicate = false;
         for (RecipeLink recipeLink : recipes) {
             if (!curRecipe.getType().equals(recipeLink.getType())) {
@@ -150,7 +151,7 @@ public class RecipeTransformer {
                 continue;
             }
 
-            foundDuplicate |= curRecipe.handleDuplicate(recipeLink, compareSettings);
+            foundDuplicate |= curRecipe.handleDuplicate(recipeLink, compareContext);
         }
 
         return foundDuplicate;

--- a/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
+++ b/Common/src/main/java/com/almostreliable/unified/utils/JsonCompare.java
@@ -271,7 +271,7 @@ public final class JsonCompare {
     public record CompareContext(CompareSettings settings, List<String> compareFields) {
         public static CompareContext create(CompareSettings settings, RecipeLink curRecipe) {
             Set<String> compareFields = curRecipe.getActual().keySet();
-            if (!settings.ignoredFields.isEmpty()) {
+            if (settings.hasIgnoredFields()) {
                 compareFields = new HashSet<>(compareFields);
                 compareFields.removeAll(settings.ignoredFields);
             }


### PR DESCRIPTION
Hello!

## Proposed Changes

This PR optimizes some very hot areas when starting AlmostUnified in a large pack.
I tested this against ATM10 and was able to speed up this mod's loading by about 40%, from 9.5 seconds to 5.7 seconds on my machine. This is a really imprecise measurement but I am confident that it will be at least a little faster for everyone.

## Additional Context

### Future Work

Almost all the remaining time is spent in `com.google.gson.JsonObject#equals`, but trying to avoid that would require a big structural change so I stopped here. I think using java maps of values instead of `JsonObject` for `RecipeLink#getActual` could give a massive speedup, but there are probably things here I haven't considered so I did not try it.

### Performance Comparison (flame graphs)

Before:

(9.5 seconds)
![Screenshot 2024-10-09 at 9 03 55 AM](https://github.com/user-attachments/assets/b95901e2-8d43-4616-ab92-e596a1f3caf6)

After:

(5.7 seconds)
![Screenshot 2024-10-09 at 9 03 40 AM](https://github.com/user-attachments/assets/e3a7521b-7be5-4995-889b-cd6210a8cb04)
