### PR TITLE
Eagerly parse and compare the shaped recipe output item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-- /
+
+- drastically improved startup performance ([Shadows-of-Fire](https://github.com/Shadows-of-Fire)@[#115](https://github.com/AlmostReliable/almostunified/pull/115))
 
 ## [1.2.3] - 2024-12-22
 

--- a/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
+++ b/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
@@ -27,6 +27,8 @@ public final class RecipeLink implements RecipeData {
      */
     private static final Map<String, ResourceLocation> PARSED_TYPE_CACHE = new HashMap<>();
 
+    private static final ResourceLocation SHAPED_RECIPE = PARSED_TYPE_CACHE.computeIfAbsent("minecraft:crafting_shaped", ResourceLocation::parse);
+    
     private final ResourceLocation id;
     private final ResourceLocation type;
     private final JsonObject originalRecipe;
@@ -39,7 +41,7 @@ public final class RecipeLink implements RecipeData {
         this.id = id;
         this.originalRecipe = originalRecipe;
         this.type = type;
-        this.isShapedRecipe = type.toString().equals("minecraft:crafting_shaped");
+        this.isShapedRecipe = type == SHAPED_RECIPE; // These RLs are interned, so we can use == for comparison.
         if (this.isShapedRecipe) {
             String outputString = originalRecipe.get("result").getAsJsonObject().get("item").getAsString();
             this.shapedRecipeOutput = BuiltInRegistries.ITEM.get(ResourceLocation.parse(outputString));

--- a/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
+++ b/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
@@ -5,6 +5,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 
 import com.almostreliable.unified.AlmostUnifiedCommon;
+import com.almostreliable.unified.api.constant.RecipeConstants;
 import com.almostreliable.unified.api.unification.recipe.RecipeData;
 import com.almostreliable.unified.utils.JsonCompare;
 
@@ -26,25 +27,41 @@ public final class RecipeLink implements RecipeData {
      * Having fewer ResourceLocation instances can greatly speed up equality checking when these are used as map keys.
      */
     private static final Map<String, ResourceLocation> PARSED_TYPE_CACHE = new HashMap<>();
+    private static final ResourceLocation SHAPED_RECIPE_TYPE = PARSED_TYPE_CACHE.computeIfAbsent(
+        "minecraft:crafting_shaped",
+        ResourceLocation::parse
+    );
+    private static final ResourceLocation SHAPELESS_RECIPE_TYPE = PARSED_TYPE_CACHE.computeIfAbsent(
+        "minecraft:crafting_shapeless",
+        ResourceLocation::parse
+    );
 
-    private static final ResourceLocation SHAPED_RECIPE = PARSED_TYPE_CACHE.computeIfAbsent("minecraft:crafting_shaped", ResourceLocation::parse);
-    
     private final ResourceLocation id;
     private final ResourceLocation type;
     private final JsonObject originalRecipe;
-    private final boolean isShapedRecipe;
+    private final boolean isCraftingRecipe;
+
     @Nullable private DuplicateLink duplicateLink;
     @Nullable private JsonObject unifiedRecipe;
-    @Nullable private Item shapedRecipeOutput; // Ideally we would deserialize the entire ItemStack, but the context isn't available here.
+    @Nullable private Item craftingRecipeOutput;
 
     private RecipeLink(ResourceLocation id, JsonObject originalRecipe, ResourceLocation type) {
         this.id = id;
         this.originalRecipe = originalRecipe;
         this.type = type;
-        this.isShapedRecipe = type == SHAPED_RECIPE; // These RLs are interned, so we can use == for comparison.
-        if (this.isShapedRecipe) {
-            String outputString = originalRecipe.get("result").getAsJsonObject().get("item").getAsString();
-            this.shapedRecipeOutput = BuiltInRegistries.ITEM.get(ResourceLocation.parse(outputString));
+        this.isCraftingRecipe = type == SHAPED_RECIPE_TYPE || type == SHAPELESS_RECIPE_TYPE;
+
+        if (isCraftingRecipe) {
+            try {
+                String outputString = originalRecipe
+                    .getAsJsonObject(RecipeConstants.RESULT)
+                    .getAsJsonPrimitive(RecipeConstants.ID)
+                    .getAsString();
+                this.craftingRecipeOutput = BuiltInRegistries.ITEM.get(ResourceLocation.parse(outputString));
+            } catch (Exception e) {
+                AlmostUnifiedCommon.LOGGER.warn("Could not detect crafting recipe output for recipe '{}'.", id);
+                this.craftingRecipeOutput = null;
+            }
         }
     }
 
@@ -82,14 +99,16 @@ public final class RecipeLink implements RecipeData {
      */
     @Nullable
     public static RecipeLink compare(RecipeLink first, RecipeLink second, JsonCompare.CompareContext compareContext) {
+        if (first.isCraftingRecipe && first.craftingRecipeOutput != second.craftingRecipeOutput) {
+            return null;
+        }
+
         JsonObject selfActual = first.getActual();
         JsonObject toCompareActual = second.getActual();
 
         JsonObject compare = null;
-        if (first.isShapedRecipe) {
-            if (first.shapedRecipeOutput == second.shapedRecipeOutput) {
-                compare = JsonCompare.compareShaped(selfActual, toCompareActual, compareContext);
-            }
+        if (first.isCraftingRecipe) {
+            compare = JsonCompare.compareShaped(selfActual, toCompareActual, compareContext);
         } else if (JsonCompare.matches(selfActual, toCompareActual, compareContext)) {
             compare = JsonCompare.compare(compareContext.settings().getRules(), selfActual, toCompareActual);
         }

--- a/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
+++ b/Common/src/main/java/com/almostreliable/unified/unification/recipe/RecipeLink.java
@@ -1,6 +1,8 @@
 package com.almostreliable.unified.unification.recipe;
 
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 
 import com.almostreliable.unified.AlmostUnifiedCommon;
 import com.almostreliable.unified.api.unification.recipe.RecipeData;
@@ -28,13 +30,20 @@ public final class RecipeLink implements RecipeData {
     private final ResourceLocation id;
     private final ResourceLocation type;
     private final JsonObject originalRecipe;
+    private final boolean isShapedRecipe;
     @Nullable private DuplicateLink duplicateLink;
     @Nullable private JsonObject unifiedRecipe;
+    @Nullable private Item shapedRecipeOutput; // Ideally we would deserialize the entire ItemStack, but the context isn't available here.
 
     private RecipeLink(ResourceLocation id, JsonObject originalRecipe, ResourceLocation type) {
         this.id = id;
         this.originalRecipe = originalRecipe;
         this.type = type;
+        this.isShapedRecipe = type.toString().equals("minecraft:crafting_shaped");
+        if (this.isShapedRecipe) {
+            String outputString = originalRecipe.get("result").getAsJsonObject().get("item").getAsString();
+            this.shapedRecipeOutput = BuiltInRegistries.ITEM.get(ResourceLocation.parse(outputString));
+        }
     }
 
     @Nullable
@@ -75,8 +84,10 @@ public final class RecipeLink implements RecipeData {
         JsonObject toCompareActual = second.getActual();
 
         JsonObject compare = null;
-        if (first.getType().toString().equals("minecraft:crafting_shaped")) {
-            compare = JsonCompare.compareShaped(selfActual, toCompareActual, compareContext);
+        if (first.isShapedRecipe) {
+            if (first.shapedRecipeOutput == second.shapedRecipeOutput) {
+                compare = JsonCompare.compareShaped(selfActual, toCompareActual, compareContext);
+            }
         } else if (JsonCompare.matches(selfActual, toCompareActual, compareContext)) {
             compare = JsonCompare.compare(compareContext.settings().getRules(), selfActual, toCompareActual);
         }


### PR DESCRIPTION
This PR adds logic to `RecipeLink` which engages when the `RecipeLink` is holding a shaped recipe (of type `minecraft:crafting_shaped`) to speed up the matching process against other shaped recipes.

Recipe Links are compared `O(N^2)` times against other recipe links of the same type - in ATM10, there are ~70k recipes, with the vast majority being shaped, so then number of comparisons is... probably in the billions, at least (60k^2 is 3.6B).

So, to preempt the common case, when a `RecipeLink` for a shaped recipe is encountered, we parse the output item from the underlying `JsonObject`, and preemptively compare it using reference equality.

This brings AU's startup time in ATM10 from 20s to 1.6s (12.5x faster // 92% uplift). You could probably optimize this further by pushing the `HolderLookup.Provider` down into the `RecipeLink` ctor and being able to parse the entire `ItemStack`, but it seems like this gets the supermajority of the cases so there might not be much point.