### PR TITLE
Updated 1.20.1 - Build Fixes

### DIFF
--- a/Common/src/main/java/com/almostreliable/unified/api/ModConstants.java
+++ b/Common/src/main/java/com/almostreliable/unified/api/ModConstants.java
@@ -1,33 +1,31 @@
 package com.almostreliable.unified.api;
 
 @SuppressWarnings("SpellCheckingInspection")
-public final class ModConstants {
+public interface ModConstants {
     // recipe viewers
-    public static final String JEI = "jei";
-    public static final String REI = "roughlyenoughitems";
+    String JEI = "jei";
+    String REI = "roughlyenoughitems";
 
     // custom unify handlers
-    public static final String AD_ASTRA = "ad_astra";
-    public static final String APPLIED_ENERGISTICS = "ae2";
-    public static final String ALLOY_FORGERY = "alloy_forgery";
-    public static final String AMETHYST_IMBUEMENT = "amethyst_imbuement";
-    public static final String ARS_CREO = "ars_creo";
-    public static final String ARS_ELEMENTAL = "ars_elemental";
-    public static final String ARS_NOUVEAU = "ars_nouveau";
-    public static final String ARS_SCALAES = "ars_scalaes";
-    public static final String BLOOD_MAGIC = "bloodmagic";
-    public static final String CYCLIC = "cyclic";
-    public static final String ENDER_IO = "enderio";
-    public static final String GREGTECH_MODERN = "gtceu";
-    public static final String IMMERSIVE_ENGINEERING = "immersiveengineering";
-    public static final String INTEGRATED_DYNAMICS = "integrateddynamics";
-    public static final String MEKANISM = "mekanism";
-    public static final String MODERN_INDUSTRIALIZATION = "modern_industrialization";
-    public static final String WOODENCOG = "woodencog";
-    public static final String TERRAFIRMACRAFT = "tfc";
-    public static final String ADVANCED_TFC_TECH = "advancedtfctech";
-    public static final String FIRMALIFE = "firmalife";
-    public static final String TFC_WATER_FLASKS = "waterflasks";
-
-    private ModConstants() {}
+    String AD_ASTRA = "ad_astra";
+    String APPLIED_ENERGISTICS = "ae2";
+    String ALLOY_FORGERY = "alloy_forgery";
+    String AMETHYST_IMBUEMENT = "amethyst_imbuement";
+    String ARS_CREO = "ars_creo";
+    String ARS_ELEMENTAL = "ars_elemental";
+    String ARS_NOUVEAU = "ars_nouveau";
+    String ARS_SCALAES = "ars_scalaes";
+    String BLOOD_MAGIC = "bloodmagic";
+    String CYCLIC = "cyclic";
+    String ENDER_IO = "enderio";
+    String GREGTECH_MODERN = "gtceu";
+    String IMMERSIVE_ENGINEERING = "immersiveengineering";
+    String INTEGRATED_DYNAMICS = "integrateddynamics";
+    String MEKANISM = "mekanism";
+    String MODERN_INDUSTRIALIZATION = "modern_industrialization";
+    String WOODENCOG = "woodencog";
+    String TERRAFIRMACRAFT = "tfc";
+    String ADVANCED_TFC_TECH = "advancedtfctech";
+    String FIRMALIFE = "firmalife";
+    String TFC_WATER_FLASKS = "waterflasks";
 }

--- a/Fabric/build.gradle.kts
+++ b/Fabric/build.gradle.kts
@@ -7,7 +7,7 @@ val reiVersion: String by project
 val emiVersion: String by project
 
 plugins {
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "8.+"
 }
 
 architectury {

--- a/Forge/build.gradle.kts
+++ b/Forge/build.gradle.kts
@@ -10,7 +10,7 @@ val emiVersion: String by project
 val extraModsPrefix = "extra-mods"
 
 plugins {
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "8.+"
 }
 
 architectury {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,8 @@ val githubUser: String by project
 
 plugins {
     id("architectury-plugin") version "3.4.+"
-    id("dev.architectury.loom") version "1.4.+" apply false
-    id("com.github.johnrengelman.shadow") version "8.1.1" apply false
+    id("dev.architectury.loom") version "1.9.+" apply false
+    id("com.gradleup.shadow") version "8.+" apply false
     java
     `maven-publish`
 }
@@ -182,7 +182,7 @@ subprojects {
         return@subprojects
     }
 
-    apply(plugin = "com.github.johnrengelman.shadow")
+    apply(plugin = "com.gradleup.shadow")
 
     extensions.configure<LoomGradleExtensionAPI> {
         runs {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ junitVersion = 5.9.0
 parchmentVersion = 2023.09.03
 
 # Mod Dependencies
-jeiVersion = 15.1.0.18
+jeiVersion = 15.20.0.106
 reiVersion = 12.0.625
 emiVersion = 1.1.2
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase = GRADLE_USER_HOME
 distributionPath = wrapper/dists
-distributionUrl = https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl = https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase = GRADLE_USER_HOME
 zipStorePath = wrapper/dists


### PR DESCRIPTION
## Issue Reference
Not Applicable.

## Proposed Changes
- fixed deprecated java constants file semantics
  - this should help with code clarity 
  - prevent even reflective creation of an instance 
  - ... is why this practice is adopted over private final constructors
  - **the implementation should be reworked in other branches but this is only solving 1.20.1**
- fixed deprecated uses 
  - gradle
  - unmaintained shadow jar plugin
  - jei reference to current 1.20.1 release

## Additional Context
This isn't a big thing and only improves compatibility when Forge is the mod loader despite not being a forge specific change. Fabric and others have a more java-like dependency management and won't see any real postivies except compatibility and semantic.